### PR TITLE
Add optional precision argument to format()

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ By default all values are rounded to the nearest integer.
 ```
 > 513 KiB
 
-Increasing the precision with `setPrecision($precision)` allows the specified amount of digits after the decimal point.
+The default precision can be increased with `setPrecision($precision)`. Increasing the precision allows the specified amount of digits after the decimal point.
+
 ```php
 (new ByteFormatter)->setPrecision(2)->format(0x80233);
 ```
@@ -54,6 +55,13 @@ needed.
 (new ByteFormatter)->setPrecision(2)->format(0x80200);
 ```
 > 512.5 KiB
+
+The default precision can be overridden on a per-format basis using the optional precision argument to `format()`.
+
+```php
+(new ByteFormatter)->setPrecision(2)->format(0x80233, 4);
+```
+> 512.5498 KiB
 
 Output format
 -------------

--- a/src/Byte/ByteFormatter.php
+++ b/src/Byte/ByteFormatter.php
@@ -34,11 +34,12 @@ class ByteFormatter
         ;
     }
 
-    public function format($bytes)
+    public function format($bytes, $precision = null)
     {
+        $precision = $precision === null ? $this->precision : $precision;
         $log = log($bytes, $this->base);
         $exponent = max(0, $log|0);
-        $value = round(pow($this->base, $log - $exponent), $this->precision);
+        $value = round(pow($this->base, $log - $exponent), $precision);
         $units = $this->getUnitDecorator()->decorate($exponent, $this->base, $value);
 
         return trim(sprintf($this->normalizedFormat, $value, $units));

--- a/test/Integration/ByteFormatterTest.php
+++ b/test/Integration/ByteFormatterTest.php
@@ -77,11 +77,8 @@ final class ByteFormatterTest extends \PHPUnit_Framework_TestCase
     /** @dataProvider providePrecisionIntegers */
     public function testPrecision($integer, $formatted)
     {
-        $withArgument = $this->formatter->setPrecision(5)->format($integer, 2);
-        $withMethod = $this->formatter->setPrecision(2)->format($integer);
-
-        $this->assertSame($formatted, $withMethod);
-        $this->assertSame($withMethod, $withArgument);
+        $this->assertSame($formatted, $this->formatter->setPrecision(2)->format($integer));
+        $this->assertSame($formatted, $this->formatter->setPrecision(5)->format($integer, 2));
     }
 
     public function providePrecisionIntegers()

--- a/test/Integration/ByteFormatterTest.php
+++ b/test/Integration/ByteFormatterTest.php
@@ -77,7 +77,11 @@ final class ByteFormatterTest extends \PHPUnit_Framework_TestCase
     /** @dataProvider providePrecisionIntegers */
     public function testPrecision($integer, $formatted)
     {
-        $this->assertSame($formatted, $this->formatter->setPrecision(2)->format($integer));
+        $withArgument = $this->formatter->setPrecision(5)->format($integer, 2);
+        $withMethod = $this->formatter->setPrecision(2)->format($integer);
+
+        $this->assertSame($formatted, $withMethod);
+        $this->assertSame($withMethod, $withArgument);
     }
 
     public function providePrecisionIntegers()

--- a/test/Integration/DocumentationTest.php
+++ b/test/Integration/DocumentationTest.php
@@ -22,6 +22,8 @@ final class DocumentationTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('512.55 KiB', (new ByteFormatter)->setPrecision(2)->format(0x80233));
 
         $this->assertSame('512.5 KiB', (new ByteFormatter)->setPrecision(2)->format(0x80200));
+
+        $this->assertSame('512.5498 KiB', (new ByteFormatter)->setPrecision(2)->format(0x80233, 4));
     }
 
     public function testOutputFormat()


### PR DESCRIPTION
Per our discussion: This change adds an optional precision argument to `format()`, allowing users to override the default precision on a per-format basis. I tried to update the documentation and tests, hopefully i got them right.