### PR TITLE
PHP 8.2: Fix deprecated string interpolation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         php:
+          - 8.2
           - 8.1
           - 8.0
         dependencies:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
+          ini-values: error_reporting=-1
 
       - name: Validate composer.json
         run: composer validate

--- a/src/Byte/ByteFormatter.php
+++ b/src/Byte/ByteFormatter.php
@@ -72,7 +72,7 @@ class ByteFormatter
      */
     private function formatValue(float $value, int $precision): string
     {
-        $formatted = sprintf("%0.${precision}F", $value);
+        $formatted = sprintf("%0.{$precision}F", $value);
 
         if ($this->hasAutomaticPrecision()) {
             // [0 => integer part, 1 => fractional part].


### PR DESCRIPTION
Hi,

PHP 8.2 has deprecated this format of string interpolation:

```php
// deprecated
$string = "hello ${name}";

// ok
$string = "hello {$name}";
```

Source: https://www.php.net/manual/en/migration82.deprecated.php
